### PR TITLE
Fixed reving down rpm, while in neutral or clutch is pressed.

### DIFF
--- a/FS17_GearboxAddon/gearboxMogli.lua
+++ b/FS17_GearboxAddon/gearboxMogli.lua
@@ -8272,7 +8272,7 @@ function gearboxMogliMotor:mrGbMUpdateGear( accelerationPedal )
 		else
 			self.lastThrottle = math.max( self.vehicle.mrGbMS.HandThrottle, accelerationPedal )
 		end
-		if self.lastThrottle > 0 then			
+		if self.lastThrottle > 0 and self.lastThrottle > ( self.lastMotorRpm / self.maxRpm )  then
 			self.lastMotorRpm  = Utils.clamp( self.lastMotorRpm + 5 * self.lastThrottle * self.tickDt * self.vehicle.mrGbMS.RpmIncFactor, 
 																			 self.minRequiredRpm, 
 																			 self:getThrottleMaxRpm( ) )
@@ -8938,3 +8938,4 @@ function gearboxMogli:mrGbMDebug()
 	print("debugGearShift: "..tostring(gearboxMogli.debugGearShift))
 end
 end
+

--- a/src/gearboxMogli.lua
+++ b/src/gearboxMogli.lua
@@ -8272,7 +8272,7 @@ function gearboxMogliMotor:mrGbMUpdateGear( accelerationPedal )
 		else
 			self.lastThrottle = math.max( self.vehicle.mrGbMS.HandThrottle, accelerationPedal )
 		end
-		if self.lastThrottle > 0 then			
+		if self.lastThrottle > 0 and self.lastThrottle > ( self.lastMotorRpm / self.maxRpm )  then
 			self.lastMotorRpm  = Utils.clamp( self.lastMotorRpm + 5 * self.lastThrottle * self.tickDt * self.vehicle.mrGbMS.RpmIncFactor, 
 																			 self.minRequiredRpm, 
 																			 self:getThrottleMaxRpm( ) )
@@ -8938,3 +8938,4 @@ function gearboxMogli:mrGbMDebug()
 	print("debugGearShift: "..tostring(gearboxMogli.debugGearShift))
 end
 end
+


### PR DESCRIPTION
As I was annoyed with rev dropping while driving with G27, I prototyped proper smoothing which was discussed in the #49.

Please take a look and try it out if it works for you too ;)

NOTE: I am still fiddling around with proper integration to configured "revDownMs". Currently I just put hardcoded  factor of 0.98 there as it felt natural. This means that on each update call, rpm is dropped for 2% until it reaches actual throttle value.