### PR TITLE
fix handbrake display logic

### DIFF
--- a/src/gearboxMogli.lua
+++ b/src/gearboxMogli.lua
@@ -4841,17 +4841,17 @@ function gearboxMogli:draw()
 			revShow = not revShow
 		end
 			
-		if not ( self:mrGbMGetNeutralActive() ) then
-			if revShow then
-				gearboxMogli.ovArrowDownWhite:render()
-			else
-				gearboxMogli.ovArrowUpWhite:render()
-			end
-		elseif self.mrGbMS.Handbrake then
+		if self.mrGbMS.Handbrake then
 			if revShow then
 				gearboxMogli.ovHandBrakeDown:render()
 			else
 				gearboxMogli.ovHandBrakeUp:render()
+			end
+		elseif not ( self:mrGbMGetNeutralActive() ) then
+			if revShow then
+				gearboxMogli.ovArrowDownWhite:render()
+			else
+				gearboxMogli.ovArrowUpWhite:render()
 			end
 		else
 			if revShow then


### PR DESCRIPTION
The handbrake icon would only show if gearbox was in neutral. This change makes the handbrake icon display both in-gear and in neutral, which feels more natural to me.